### PR TITLE
authors redux per Chairs Request

### DIFF
--- a/draft-ietf-nmop-rfc3535-20years-later.md
+++ b/draft-ietf-nmop-rfc3535-20years-later.md
@@ -36,6 +36,8 @@ author:
    fullname: Reshad Rahman
    organization: Equinix
    email: rrahman@equinix.com
+
+contributor:
  -
    fullname: Lionel Tailhardat
    organization: Orange


### PR DESCRIPTION
Received a request from the Chairs to limit the list of authors in the front page to 5 (per the current IETF policy).

If this proposal is not OK, I can move myself to the contribution list.